### PR TITLE
Update thiserror from 2.0.3 to 2.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bindgen = []
 [dependencies]
 flatbuffers = "23.5.26"
 libc = "0.2.151"
-thiserror = "2.0.3"
+thiserror = "2.0.7"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
Using rev 46ca13dffdfe2320d4488912506c7bfa02afe284 with `nostr` crate version `0.37.0` with feature `nip59` enabled yields the following error:
```
error: failed to select a version for `syn`.
    ... required by package `thiserror-impl v2.0.3`
    ... which satisfies dependency `thiserror-impl = "=2.0.3"` of package `thiserror v2.0.3`
    ... which satisfies dependency `thiserror = "^2.0.3"` of package `nostrdb v0.4.0 (https://github.com
    ... which satisfies git dependency `nostrdb` of package `hoot-app v0.1.0 (/home/jack/Developer/csys/
versions that meet the requirements `^2.0.87` are: 2.0.90, 2.0.89, 2.0.88, 2.0.87

all possible versions conflict with previously selected packages.

  previously selected package `syn v2.0.60`
    ... which satisfies dependency `syn = "^2.0.46"` (locked to 2.0.60) of package `async-trait v0.1.80`
    ... which satisfies dependency `async-trait = "^0.1"` (locked to 0.1.80) of package `nostr v0.37.0`
    ... which satisfies dependency `nostr = "^0.37.0"` (locked to 0.37.0) of package `hoot-app v0.1.0 (/

failed to select a version for `syn` which could resolve this conflict
```

I have updated `thiserror` to version `2.0.7` to mitigate this dependency conflict. It works.