### PR TITLE
Add bech32_{nprofile,nevent,naddr}::relays_to_strings

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -71,6 +71,12 @@ impl bindings::bech32_nprofile {
     pub fn pubkey(&self) -> &[u8; 32] {
         unsafe { &*(self.pubkey as *const [u8; 32]) }
     }
+
+    pub fn relays_iter(&self) -> impl Iterator<Item = &str> {
+        self.relays.relays[0..(self.relays.num_relays as usize)]
+            .iter()
+            .map(|block| block.as_str())
+    }
 }
 
 impl bindings::bech32_npub {
@@ -97,6 +103,20 @@ impl bindings::bech32_nevent {
             }
             Some(&*(self.pubkey as *const [u8; 32]))
         }
+    }
+
+    pub fn relays_iter(&self) -> impl Iterator<Item = &str> {
+        self.relays.relays[0..(self.relays.num_relays as usize)]
+            .iter()
+            .map(|block| block.as_str())
+    }
+}
+
+impl bindings::bech32_naddr {
+    pub fn relays_iter(&self) -> impl Iterator<Item = &str> {
+        self.relays.relays[0..(self.relays.num_relays as usize)]
+            .iter()
+            .map(|block| block.as_str())
     }
 }
 
@@ -421,6 +441,8 @@ mod tests {
                         assert_eq!(p.relays.num_relays, 2);
                         assert_eq!(p.relays.relays[0].as_str(), "wss://r.x.com");
                         assert_eq!(p.relays.relays[1].as_str(), "wss://djbas.sadkb.com");
+                        let relays: Vec<&str> = p.relays_iter().collect();
+                        assert_eq!(relays, vec!["wss://r.x.com", "wss://djbas.sadkb.com"]);
                         nprofile_check = true;
                     }
                 }

--- a/src/util/nip10.rs
+++ b/src/util/nip10.rs
@@ -62,21 +62,13 @@ impl NoteReplyBuf {
                 continue;
             }
 
-            if self
-                .root
-                .as_ref()
-                .map_or(false, |x| x.index == index as u16)
-            {
+            if self.root.as_ref().is_some_and(|x| x.index == index as u16) {
                 root = Some(tag_to_note_id_ref(
                     tag,
                     self.root.as_ref().unwrap().marker,
                     index,
                 ))
-            } else if self
-                .reply
-                .as_ref()
-                .map_or(false, |x| x.index == index as u16)
-            {
+            } else if self.reply.as_ref().is_some_and(|x| x.index == index as u16) {
                 reply = Some(tag_to_note_id_ref(
                     tag,
                     self.reply.as_ref().unwrap().marker,
@@ -85,7 +77,7 @@ impl NoteReplyBuf {
             } else if self
                 .mention
                 .as_ref()
-                .map_or(false, |x| x.index == index as u16)
+                .is_some_and(|x| x.index == index as u16)
             {
                 mention = Some(tag_to_note_id_ref(
                     tag,


### PR DESCRIPTION
This accessor safely fetches the optional relay hints from the three mention types that have them