### PR TITLE
Take an iterator of `&str` in `Filter::tags`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = "2.0.7"
 futures = "0.3.31"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -491,13 +491,13 @@ impl FilterBuilder {
         self
     }
 
-    pub fn tags<I>(mut self, tags: I, tag: char) -> Self
+    pub fn tags<'a, I>(mut self, tags: I, tag: char) -> Self
     where
-        I: IntoIterator<Item = String>,
+        I: IntoIterator<Item = &'a str>,
     {
         self.start_tag_field(tag).unwrap();
         for tag in tags {
-            self.add_str_element(&tag).unwrap();
+            self.add_str_element(tag).unwrap();
         }
         self.end_field();
         self


### PR DESCRIPTION
Take an iterator of `&str` instead of `String` in `Filter::tags`.

In a separated commit (776b722c943aa5409ade4935b4c3b71d81368f3a), I also removed `tracing-subscriber` dep since it was unused.