### PR TITLE
Fix build.rs to link Security framework only for Apple targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -120,7 +120,7 @@ fn main() {
     }
 
     // Link Security framework on macOS
-    if env::var("TARGET").unwrap().contains("apple") {
+    if std::env::var("CARGO_CFG_TARGET_VENDOR").unwrap() == "apple" {
         println!("cargo:rustc-link-lib=framework=Security");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -120,7 +120,7 @@ fn main() {
     }
 
     // Link Security framework on macOS
-    if cfg!(target_os = "macos") {
+    if env::var("TARGET").unwrap().contains("apple") {
         println!("cargo:rustc-link-lib=framework=Security");
     }
 


### PR DESCRIPTION
Just a quick fix, the current code was checking the build machine instead of the actual target, the actual targets are `aarch64-linux-android` for android, and `aarch64-apple-darwin` + `x86_64-apple-darwin` for macos, so this code just looks for the string "apple" in the target and then links the security framework, instead of doing it whenever building on macos 