### PR TITLE
implement streaming fold queries

### DIFF
--- a/src/bindings_posix.rs
+++ b/src/bindings_posix.rs
@@ -2969,6 +2969,64 @@ pub type ndb_sub_fn =
     ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void, subid: u64)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct ndb_query_result {
+    pub note: *mut ndb_note,
+    pub note_size: u64,
+    pub note_id: u64,
+}
+#[test]
+fn bindgen_test_layout_ndb_query_result() {
+    const UNINIT: ::std::mem::MaybeUninit<ndb_query_result> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<ndb_query_result>(),
+        24usize,
+        concat!("Size of: ", stringify!(ndb_query_result))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ndb_query_result>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ndb_query_result))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).note) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_result),
+            "::",
+            stringify!(note)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).note_size) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_result),
+            "::",
+            stringify!(note_size)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).note_id) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_result),
+            "::",
+            stringify!(note_id)
+        )
+    );
+}
+pub type ndb_visitor_fn = ::std::option::Option<
+    unsafe extern "C" fn(
+        ctx: *mut ::std::os::raw::c_void,
+        res: *mut ndb_query_result,
+    ) -> ndb_visitor_action,
+>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct ndb_id_cb {
     pub fn_: ndb_id_fn,
     pub data: *mut ::std::os::raw::c_void,
@@ -5274,58 +5332,12 @@ fn bindgen_test_layout_ndb_block_iterator() {
         )
     );
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ndb_query_result {
-    pub note: *mut ndb_note,
-    pub note_size: u64,
-    pub note_id: u64,
-}
-#[test]
-fn bindgen_test_layout_ndb_query_result() {
-    const UNINIT: ::std::mem::MaybeUninit<ndb_query_result> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ndb_query_result>(),
-        24usize,
-        concat!("Size of: ", stringify!(ndb_query_result))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ndb_query_result>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ndb_query_result))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).note) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ndb_query_result),
-            "::",
-            stringify!(note)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).note_size) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ndb_query_result),
-            "::",
-            stringify!(note_size)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).note_id) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ndb_query_result),
-            "::",
-            stringify!(note_id)
-        )
-    );
-}
+pub const ndb_query_type_NDB_QUERY_TYPE_STANDARD: ndb_query_type = 1;
+pub const ndb_query_type_NDB_QUERY_TYPE_VISITOR: ndb_query_type = 2;
+pub type ndb_query_type = ::std::os::raw::c_uint;
+pub const ndb_visitor_action_NDB_VISITOR_STOP: ndb_visitor_action = 0;
+pub const ndb_visitor_action_NDB_VISITOR_CONT: ndb_visitor_action = 1;
+pub type ndb_visitor_action = i32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ndb_query_results {
@@ -5353,6 +5365,208 @@ fn bindgen_test_layout_ndb_query_results() {
             stringify!(ndb_query_results),
             "::",
             stringify!(cur)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ndb_query_state {
+    pub type_: ndb_query_type,
+    pub limit: u64,
+    pub __bindgen_anon_1: ndb_query_state__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union ndb_query_state__bindgen_ty_1 {
+    pub query: ndb_query_state__bindgen_ty_1__bindgen_ty_1,
+    pub visitor: ndb_query_state__bindgen_ty_1__bindgen_ty_2,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ndb_query_state__bindgen_ty_1__bindgen_ty_1 {
+    pub capacity: ::std::os::raw::c_int,
+    pub results: ndb_query_results,
+}
+#[test]
+fn bindgen_test_layout_ndb_query_state__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<ndb_query_state__bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<ndb_query_state__bindgen_ty_1__bindgen_ty_1>(),
+        32usize,
+        concat!(
+            "Size of: ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ndb_query_state__bindgen_ty_1__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).capacity) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(capacity)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).results) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(results)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ndb_query_state__bindgen_ty_1__bindgen_ty_2 {
+    pub visited: u64,
+    pub ctx: *mut ::std::os::raw::c_void,
+    pub done: ::std::os::raw::c_int,
+    pub visitor: ndb_visitor_fn,
+}
+#[test]
+fn bindgen_test_layout_ndb_query_state__bindgen_ty_1__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<ndb_query_state__bindgen_ty_1__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<ndb_query_state__bindgen_ty_1__bindgen_ty_2>(),
+        32usize,
+        concat!(
+            "Size of: ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_2)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ndb_query_state__bindgen_ty_1__bindgen_ty_2>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_2)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).visited) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(visited)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).ctx) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(ctx)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).done) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(done)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).visitor) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(visitor)
+        )
+    );
+}
+#[test]
+fn bindgen_test_layout_ndb_query_state__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<ndb_query_state__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<ndb_query_state__bindgen_ty_1>(),
+        32usize,
+        concat!("Size of: ", stringify!(ndb_query_state__bindgen_ty_1))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ndb_query_state__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ndb_query_state__bindgen_ty_1))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).query) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state__bindgen_ty_1),
+            "::",
+            stringify!(query)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).visitor) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state__bindgen_ty_1),
+            "::",
+            stringify!(visitor)
+        )
+    );
+}
+#[test]
+fn bindgen_test_layout_ndb_query_state() {
+    const UNINIT: ::std::mem::MaybeUninit<ndb_query_state> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<ndb_query_state>(),
+        48usize,
+        concat!("Size of: ", stringify!(ndb_query_state))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ndb_query_state>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ndb_query_state))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).limit) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ndb_query_state),
+            "::",
+            stringify!(limit)
         )
     );
 }
@@ -5863,6 +6077,15 @@ extern "C" {
         results: *mut ndb_query_result,
         result_capacity: ::std::os::raw::c_int,
         count: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn ndb_query_visit(
+        txn: *mut ndb_txn,
+        filters: *mut ndb_filter,
+        num_filters: ::std::os::raw::c_int,
+        visitor: ndb_visitor_fn,
+        ctx: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {


### PR DESCRIPTION
## Streaming query results in `ndb` (without collecting into a Vec)

This change adds “streaming” query operators to `ndb`: you can now walk through query results **one note at a time** and compute something **as you go**, instead of first materializing all results into a list.

That matters because a lot of real tasks don’t need “all the notes”:

* counting matches
* checking whether *any* match exists
* verifying that *all* matches satisfy a condition
* finding the first interesting item
* stopping after N results or after a budget is hit

With this commit, those patterns become fast and direct.

---

## The mental model

### Before (common pattern)

You’d typically do something like:

1. query
2. collect results
3. iterate in Rust

That works, but can waste time/memory if the result set is large or you could have short-circuited early.

### Now

You can run a query and provide a closure that’s called **for each matching note**, with a running “accumulator” value you control.

---

## 1) `count`: how many notes match?

This is the simplest “aggregation” and is now built-in:

```rust
use nostrdb::{Ndb, Transaction, Filter, Result};

fn count_kind1(ndb: &Ndb, txn: &Transaction) -> Result<usize> {
    let filters = [Filter::new().kinds(vec![1]).build()];
    ndb.count(txn, &filters)
}
```

Why it’s nice: it can count by streaming notes, without building a `Vec<Note>`.

---

## 2) `fold`: accumulate over results (no early exit)

`fold` threads an accumulator through every matching note and returns the final value.

### Example: total bytes of all note content

```rust
use nostrdb::{Ndb, Transaction, Filter, Result};

fn total_content_len(ndb: &Ndb, txn: &Transaction) -> Result<usize> {
    let filters = [Filter::new().kinds(vec![1]).build()];

    ndb.fold(txn, &filters, 0usize, |acc, note| {
        acc + note.content().len()
    })
}
```

### Example: collect up to you (but note: this collects *everything*)

```rust
use nostrdb::{Ndb, Transaction, Filter, Result, Note};

fn collect_all<'txn>(ndb: &Ndb, txn: &'txn Transaction) -> Result<Vec<Note<'txn>>> {
    let filters = [Filter::new().kinds(vec![1]).build()];

    ndb.fold(txn, &filters, Vec::new(), |mut acc, note| {
        acc.push(note);
        acc
    })
}
```

If you want “collect but stop early”, that’s `try_fold`.

---

## 3) `try_fold`: accumulate *and* stop early

`try_fold` is like `fold`, but your closure can return:

* `ControlFlow::Continue(next_acc)` → keep scanning
* `ControlFlow::Break(done)` → stop now and return `done`

### Example: stop after collecting 10 notes

```rust
use nostrdb::{Ndb, Transaction, Filter, Result, Note};
use std::ops::ControlFlow;

fn collect_first_n<'txn>(
    ndb: &Ndb,
    txn: &'txn Transaction,
    n: usize,
) -> Result<Vec<Note<'txn>>> {
    let filters = [Filter::new().kinds(vec![1]).build()];

    ndb.try_fold(txn, &filters, Vec::new(), |mut acc, note| {
        acc.push(note);
        if acc.len() >= n {
            ControlFlow::Break(acc)
        } else {
            ControlFlow::Continue(acc)
        }
    })
}
```

### Example: stop once a “budget” is reached (e.g., total bytes)

```rust
use nostrdb::{Ndb, Transaction, Filter, Result};
use std::ops::ControlFlow;

fn scan_until_budget(ndb: &Ndb, txn: &Transaction, budget: usize) -> Result<usize> {
    let filters = [Filter::new().kinds(vec![1]).build()];

    ndb.try_fold(txn, &filters, 0usize, |acc, note| {
        let next = acc + note.content().len();
        if next >= budget {
            ControlFlow::Break(next)
        } else {
            ControlFlow::Continue(next)
        }
    })
}
```

---

## 4) `any` / `all`: predicate checks with short-circuiting

These are built on `try_fold`, so they can stop early.

### `any`: does at least one match satisfy this?

```rust
use nostrdb::{Ndb, Transaction, Filter, Result};

fn has_hello(ndb: &Ndb, txn: &Transaction) -> Result<bool> {
    let filters = [Filter::new().kinds(vec![1]).build()];

    ndb.any(txn, &filters, |note| note.content().contains("hello"))
}
```

Semantics:

* empty result set → `false`
* stops at first `true`

### `all`: do all matches satisfy this?

```rust
use nostrdb::{Ndb, Transaction, Filter, Result};

fn all_non_empty(ndb: &Ndb, txn: &Transaction) -> Result<bool> {
    let filters = [Filter::new().kinds(vec![1]).build()];

    ndb.all(txn, &filters, |note| !note.content().is_empty())
}
```

Semantics:

* empty result set → `true` (vacuous truth)
* stops at first `false`

---

## 5) `find_map`: “give me the first useful thing”

This is the query/visitor analogue of `Iterator::find_map`.

### Example: return the first note containing “world”

```rust
use nostrdb::{Ndb, Transaction, Filter, Result, Note};

fn first_world<'txn>(ndb: &Ndb, txn: &'txn Transaction) -> Result<Option<Note<'txn>>> {
    let filters = [Filter::new().kinds(vec![1]).build()];

    ndb.find_map(txn, &filters, |note| {
        if note.content().contains("world") {
            Some(note)
        } else {
            None
        }
    })
}
```

Semantics:

* returns `Ok(Some(value))` on first match and stops scanning
* returns `Ok(None)` if nothing matched

---

## What’s happening under the hood (in plain terms)

The database exposes a low-level “visit each query result” callback (`ndb_query_visit`). This commit builds **stateful Rust visitors** on top of that:

* `fold` always keeps visiting
* `try_fold` can tell the DB “stop visiting” immediately

That mapping is direct: Rust’s `ControlFlow::{Continue, Break}` becomes the C visitor actions `NDB_VISITOR_CONT` / `NDB_VISITOR_STOP`.

---

## Why you should care

If you’re building query-heavy features, this gives you:

* **less memory churn** (no big result vectors unless you want them)
* **early exit** for common patterns (`any`, `all`, `find_map`, “limit N”)
* **cleaner application code** that reads like iterator logic, but runs closer to the DB
