### PR TITLE
Fix use-after-free: split owned notes into NoteBuf

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1516,7 +1516,7 @@ mod tests {
             0xe8, 0x5b, 0xa8, 0x59,
         ];
 
-        let note = NoteBuilder::new()
+        let note_buf = NoteBuilder::new()
             .kind(1)
             .content("this is the content")
             .created_at(42)
@@ -1529,6 +1529,8 @@ mod tests {
             .sign(&seckey)
             .build()
             .expect("expected build to work");
+
+        let note = note_buf.as_note();
 
         {
             let filter = Filter::new().custom(|n| n.created_at() == 43).build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use metadata::{
 pub use ndb::Ndb;
 pub use ndb_profile::{NdbProfile, NdbProfileRecord};
 pub use ndb_str::{NdbStr, NdbStrVariant};
-pub use note::{Note, NoteBuildOptions, NoteBuilder, NoteKey};
+pub use note::{Note, NoteBuf, NoteBuildOptions, NoteBuilder, NoteKey};
 pub use profile::{ProfileKey, ProfileRecord};
 pub use query::QueryResult;
 pub use relay::NoteRelays;

--- a/src/ndb_str.rs
+++ b/src/ndb_str.rs
@@ -1,8 +1,10 @@
-use crate::{bindings, Note};
+use crate::bindings;
+use std::marker::PhantomData;
 
 pub struct NdbStr<'a> {
     ndb_str: bindings::ndb_str,
-    note: Note<'a>,
+    _note_ptr: *mut bindings::ndb_note,
+    _marker: PhantomData<&'a ()>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -38,12 +40,12 @@ impl bindings::ndb_str {
 }
 
 impl<'a> NdbStr<'a> {
-    pub fn note(&self) -> &Note<'a> {
-        &self.note
-    }
-
-    pub(crate) fn new(ndb_str: bindings::ndb_str, note: Note<'a>) -> Self {
-        NdbStr { ndb_str, note }
+    pub(crate) fn new(ndb_str: bindings::ndb_str, note_ptr: *mut bindings::ndb_note) -> Self {
+        NdbStr {
+            ndb_str,
+            _note_ptr: note_ptr,
+            _marker: PhantomData,
+        }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/note.rs
+++ b/src/note.rs
@@ -1,6 +1,36 @@
 use crate::{bindings, tags::Tags, transaction::Transaction, Error, NoteRelays};
 use std::{hash::Hash, os::raw::c_uchar};
 
+/// Heap-owned note buffer. Not Clone.
+/// Use `.as_note()` to get a borrowing `Note<'_>`.
+#[derive(Debug)]
+pub struct NoteBuf {
+    ptr: *mut bindings::ndb_note,
+    size: usize,
+}
+
+impl NoteBuf {
+    pub fn as_note(&self) -> Note<'_> {
+        Note::Unowned {
+            ptr: unsafe { &*self.ptr },
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub fn as_ptr(&self) -> *mut bindings::ndb_note {
+        self.ptr
+    }
+}
+
+impl Drop for NoteBuf {
+    fn drop(&mut self) {
+        unsafe { libc::free(self.ptr as *mut libc::c_void) }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct NoteKey(u64);
 
@@ -43,19 +73,9 @@ impl<'a> NoteBuildOptions<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Note<'a> {
-    /// A note in-memory outside of nostrdb. This note is a pointer to a note in
-    /// memory and will be free'd when [Drop]ped. Method such as [Note::from_json]
-    /// will create owned notes in memory.
-    ///
-    /// [Drop]: std::ops::Drop
-    Owned {
-        ptr: *mut bindings::ndb_note,
-        size: usize,
-    },
-
-    /// An note owned somewhere else. We don't know if its from the DB or not. This
+    /// A note owned somewhere else. We don't know if its from the DB or not. This
     /// is used for custom filter callbacks.
     Unowned { ptr: &'a bindings::ndb_note },
 
@@ -70,64 +90,7 @@ pub enum Note<'a> {
     },
 }
 
-impl Clone for Note<'_> {
-    fn clone(&self) -> Self {
-        // TODO (jb55): it is still probably better to just separate owned notes
-        // into NoteBuf... that way we know exactly what we are cloning
-        // and when. Owned notes are a bit more expensive to clone, so
-        // it would be better if API encoded that explicitly.
-        match self {
-            Note::Unowned { ptr } => Note::Unowned { ptr },
-
-            Note::Owned { ptr, size } => {
-                // Allocate memory for the cloned note
-                let new_ptr = unsafe { libc::malloc(*size) as *mut bindings::ndb_note };
-                if new_ptr.is_null() {
-                    panic!("Failed to allocate memory for cloned note");
-                }
-
-                // Use memcpy to copy the memory
-                unsafe {
-                    libc::memcpy(
-                        new_ptr as *mut libc::c_void,
-                        *ptr as *const libc::c_void,
-                        *size,
-                    );
-                }
-
-                // Return a new Owned Note
-                Note::Owned {
-                    ptr: new_ptr,
-                    size: *size,
-                }
-            }
-
-            Note::Transactional {
-                ptr,
-                size,
-                key,
-                transaction,
-            } => Note::Transactional {
-                ptr: *ptr,
-                size: *size,
-                key: *key,
-                transaction,
-            },
-        }
-    }
-}
-
 impl<'a> Note<'a> {
-    /// Constructs an owned `Note`. This note is a pointer to a note in
-    /// memory and will be free'd when [Drop]ped. You normally wouldn't
-    /// use this method directly, public consumer would use from_json instead.
-    ///
-    /// [Drop]: std::ops::Drop
-    #[allow(dead_code)]
-    pub(crate) fn new_owned(ptr: *mut bindings::ndb_note, size: usize) -> Note<'static> {
-        Note::Owned { ptr, size }
-    }
-
     #[allow(dead_code)]
     pub(crate) fn new_unowned(ptr: &'a bindings::ndb_note) -> Note<'a> {
         Note::Unowned { ptr }
@@ -182,7 +145,6 @@ impl<'a> Note<'a> {
     #[inline]
     pub fn size(&self) -> usize {
         match self {
-            Note::Owned { size, .. } => *size,
             Note::Unowned { .. } => 0,
             Note::Transactional { size, .. } => *size,
         }
@@ -228,7 +190,6 @@ impl<'a> Note<'a> {
     #[inline]
     pub fn as_ptr(&self) -> *mut bindings::ndb_note {
         match self {
-            Note::Owned { ptr, .. } => *ptr,
             Note::Unowned { ptr } => *ptr as *const bindings::ndb_note as *mut bindings::ndb_note,
             Note::Transactional { ptr, .. } => *ptr,
         }
@@ -311,7 +272,7 @@ impl<'a> Note<'a> {
     #[inline]
     pub fn tags(&self) -> Tags<'a> {
         let tags = unsafe { bindings::ndb_note_tags(self.as_ptr()) };
-        Tags::new(tags, self.clone())
+        Tags::new(tags, self.as_ptr())
     }
 
     #[inline]
@@ -319,14 +280,6 @@ impl<'a> Note<'a> {
         unsafe {
             let ptr = bindings::ndb_note_sig(self.as_ptr());
             &*(ptr as *const [u8; 64])
-        }
-    }
-}
-
-impl Drop for Note<'_> {
-    fn drop(&mut self) {
-        if let Note::Owned { ptr, .. } = self {
-            unsafe { libc::free((*ptr) as *mut libc::c_void) }
         }
     }
 }
@@ -522,7 +475,7 @@ impl<'a> NoteBuilder<'a> {
         self
     }
 
-    pub fn build(&mut self) -> Option<Note<'static>> {
+    pub fn build(&mut self) -> Option<NoteBuf> {
         let mut note_ptr: *mut bindings::ndb_note = std::ptr::null_mut();
         let mut keypair = bindings::ndb_keypair::default();
 
@@ -570,7 +523,10 @@ impl<'a> NoteBuilder<'a> {
             return None;
         }
 
-        Some(Note::new_owned(note_ptr, size))
+        Some(NoteBuf {
+            ptr: note_ptr,
+            size,
+        })
     }
 }
 
@@ -622,7 +578,7 @@ mod tests {
             0xe8, 0x5b, 0xa8, 0x59,
         ];
 
-        let note = NoteBuilder::new()
+        let note_buf = NoteBuilder::new()
             .kind(1)
             .content("this is the content")
             .created_at(42)
@@ -636,6 +592,7 @@ mod tests {
             .build()
             .expect("expected build to work");
 
+        let note = note_buf.as_note();
         assert_eq!(note.created_at(), 42);
         assert_eq!(note.content(), "this is the content");
         assert_eq!(note.kind(), 1);
@@ -664,5 +621,33 @@ mod tests {
             &json[..267],
             "{\"id\":\"fb165be22c7b2518b749aabb7140c73f0887fe84475c82785700663be85ba859\",\"pubkey\":\"6c540ed060bfc2b0c5b6f09cd3ebedf980ef7bc836d69582361d20f2ad124f23\",\"created_at\":42,\"kind\":1,\"tags\":[[\"comment\",\"this is a comment\"],[\"blah\",\"something\"]],\"content\":\"this is the content\""
         );
+    }
+
+    #[test]
+    fn owned_note_tag_str_not_dangling() {
+        let note_buf = NoteBuilder::new()
+            .kind(1)
+            .content("")
+            .start_tag()
+            .tag_str("d")
+            .tag_str("my-id")
+            .build()
+            .expect("build");
+        let note = note_buf.as_note();
+
+        fn get_tag_value<'a>(note: &Note<'a>, tag_name: &str) -> Option<&'a str> {
+            for tag in note.tags() {
+                if tag.count() < 2 {
+                    continue;
+                }
+                if tag.get_str(0) == Some(tag_name) {
+                    return tag.get_str(1);
+                }
+            }
+            None
+        }
+
+        let val = get_tag_value(&note, "d");
+        assert_eq!(val, Some("my-id"));
     }
 }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,48 +1,50 @@
-use crate::{bindings, NdbStr, Note};
+use crate::{bindings, NdbStr};
+use std::marker::PhantomData;
 
-#[derive(Debug, Clone)]
-pub struct Tag<'n> {
+#[derive(Debug, Clone, Copy)]
+pub struct Tag<'a> {
     ptr: *mut bindings::ndb_tag,
-    note: Note<'n>,
+    note_ptr: *mut bindings::ndb_note,
+    _marker: PhantomData<&'a ()>,
 }
 
-impl<'n> Tag<'n> {
-    pub(crate) fn new(ptr: *mut bindings::ndb_tag, note: Note<'n>) -> Self {
-        Tag { ptr, note }
+impl<'a> Tag<'a> {
+    pub(crate) fn new(ptr: *mut bindings::ndb_tag, note_ptr: *mut bindings::ndb_note) -> Self {
+        Tag {
+            ptr,
+            note_ptr,
+            _marker: PhantomData,
+        }
     }
 
     pub fn count(&self) -> u16 {
         unsafe { bindings::ndb_tag_count(self.as_ptr()) }
     }
 
-    pub fn get_unchecked(&self, ind: u16) -> NdbStr<'n> {
+    pub fn get_unchecked(&self, ind: u16) -> NdbStr<'a> {
         let nstr = unsafe {
             bindings::ndb_tag_str(
-                self.note().as_ptr(),
+                self.note_ptr,
                 self.as_ptr(),
                 ind as ::std::os::raw::c_int,
             )
         };
-        NdbStr::new(nstr, self.note.clone())
+        NdbStr::new(nstr, self.note_ptr)
     }
 
-    pub fn get_str(&self, ind: u16) -> Option<&'n str> {
+    pub fn get_str(&self, ind: u16) -> Option<&'a str> {
         self.get(ind).and_then(|s| s.str())
     }
 
-    pub fn get_id(&self, ind: u16) -> Option<&'n [u8; 32]> {
+    pub fn get_id(&self, ind: u16) -> Option<&'a [u8; 32]> {
         self.get(ind).and_then(|s| s.id())
     }
 
-    pub fn get(&self, ind: u16) -> Option<NdbStr<'n>> {
+    pub fn get(&self, ind: u16) -> Option<NdbStr<'a>> {
         if ind >= self.count() {
             return None;
         }
         Some(self.get_unchecked(ind))
-    }
-
-    pub fn note(&self) -> &Note<'n> {
-        &self.note
     }
 
     pub fn as_ptr(&self) -> *mut bindings::ndb_tag {
@@ -59,10 +61,11 @@ impl<'a> IntoIterator for Tag<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Tags<'a> {
     ptr: *mut bindings::ndb_tags,
-    note: Note<'a>,
+    note_ptr: *mut bindings::ndb_note,
+    _marker: PhantomData<&'a ()>,
 }
 
 impl<'a> IntoIterator for Tags<'a> {
@@ -70,13 +73,17 @@ impl<'a> IntoIterator for Tags<'a> {
     type IntoIter = TagsIter<'a>;
 
     fn into_iter(self) -> TagsIter<'a> {
-        TagsIter::new(self.note().clone())
+        TagsIter::new(self.note_ptr)
     }
 }
 
 impl<'a> Tags<'a> {
-    pub(crate) fn new(ptr: *mut bindings::ndb_tags, note: Note<'a>) -> Self {
-        Tags { ptr, note }
+    pub(crate) fn new(ptr: *mut bindings::ndb_tags, note_ptr: *mut bindings::ndb_note) -> Self {
+        Tags {
+            ptr,
+            note_ptr,
+            _marker: PhantomData,
+        }
     }
 
     pub fn count(&self) -> u16 {
@@ -84,11 +91,7 @@ impl<'a> Tags<'a> {
     }
 
     pub fn iter(&self) -> TagsIter<'a> {
-        TagsIter::new(self.note.clone())
-    }
-
-    pub fn note(&self) -> &Note<'a> {
-        &self.note
+        TagsIter::new(self.note_ptr)
     }
 
     pub fn as_ptr(&self) -> *mut bindings::ndb_tags {
@@ -96,22 +99,27 @@ impl<'a> Tags<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TagsIter<'a> {
     iter: bindings::ndb_iterator,
-    note: Note<'a>,
+    note_ptr: *mut bindings::ndb_note,
+    _marker: PhantomData<&'a ()>,
 }
 
 impl<'a> TagsIter<'a> {
-    pub fn new(note: Note<'a>) -> Self {
+    pub fn new(note_ptr: *mut bindings::ndb_note) -> Self {
         let iter = bindings::ndb_iterator {
             note: std::ptr::null_mut(),
             tag: std::ptr::null_mut(),
             index: 0,
         };
-        let mut iter = TagsIter { note, iter };
+        let mut iter = TagsIter {
+            note_ptr,
+            iter,
+            _marker: PhantomData,
+        };
         unsafe {
-            bindings::ndb_tags_iterate_start(iter.note.as_ptr(), &mut iter.iter);
+            bindings::ndb_tags_iterate_start(note_ptr, &mut iter.iter);
         };
         iter
     }
@@ -121,12 +129,8 @@ impl<'a> TagsIter<'a> {
         if tag_ptr.is_null() {
             None
         } else {
-            Some(Tag::new(tag_ptr, self.note().clone()))
+            Some(Tag::new(tag_ptr, self.note_ptr))
         }
-    }
-
-    pub fn note(&self) -> &Note<'a> {
-        &self.note
     }
 
     pub fn as_ptr(&self) -> *const bindings::ndb_iterator {
@@ -138,7 +142,7 @@ impl<'a> TagsIter<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TagIter<'a> {
     tag: Tag<'a>,
     index: u16,


### PR DESCRIPTION
## Summary
- Fixes a use-after-free soundness bug where `Tag::get_str()` returned `&'a str` pointing into a cloned `Note::Owned` buffer that was freed when the `Tag` dropped
- Introduces `NoteBuf` as a non-Clone heap-owning type; `NoteBuilder::build()` now returns `Option<NoteBuf>` instead of `Option<Note<'static>>`
- `Note<'a>` is now always-borrowed and `Copy` — the tag iteration chain stores just a raw pointer + `PhantomData` instead of cloning a full `Note` at every level

## Context

`Note::Owned` clone did `malloc+memcpy`, creating independent heap memory. The tag iteration chain (`tags()` → `Tags` → `TagsIter` → `Tag` → `NdbStr`) cloned the note at every level. For owned notes, `Tag::get_str()` returned `&'a str` pointing into the clone's buffer while `'a` was tied to the original note — use-after-free when the `Tag` dropped. The borrow checker couldn't catch this because the `'a` lifetime was unsound for the `Owned` variant.

Resolves the TODO at the old `Clone for Note` impl: *"it is still probably better to just separate owned notes into NoteBuf"*.

## Test plan
- [x] Existing tests pass
- [x] New regression test `owned_note_tag_str_not_dangling` exercises the exact bug scenario
- [x] Includes Windows build fixes (regen bindings + bolt11 deps)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NIP44 keyed encryption and decryption operations
  * Added zap verification and metadata tracking (verified/unverified counts and satoshis)

* **Chores**
  * Updated dependencies
  * Refactored internal note ownership model for improved memory safety
  * Simplified Windows build configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->